### PR TITLE
Update build

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,5 @@
 module.exports = { // eslint-disable-line
+  resolver: "jest-ts-webcompat-resolver",
   transform: {
     ".(ts|tsx)": "ts-jest"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,28 @@
   "name": "ucans",
   "version": "0.8.0",
   "description": "Typescript implementation of UCANs",
+  "type": "module",
   "main": "dist/index.js",
-  "browser": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./dist/*": "./dist/*",
+    "./*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "dist/index.d.ts": [
+        "dist/index.d.ts"
+      ],
+      "dist/*": [
+        "dist/*"
+      ],
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
     "type": "git",
@@ -37,6 +56,7 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.1",
     "jest": "^27.2.0",
+    "jest-ts-webcompat-resolver": "^1.0.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,5 +1,5 @@
 import * as uint8arrays from "uint8arrays"
-import { Encodings } from "./types"
+import { Encodings } from "./types.js"
 
 export function decode(base64: string, encoding: Encodings = 'base64pad'): string {
   return uint8arrays.toString(uint8arrays.fromString(base64, encoding))

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,1 +1,1 @@
-export * as rsa from './rsa'
+export * as rsa from './rsa.js'

--- a/src/did/index.ts
+++ b/src/did/index.ts
@@ -1,3 +1,3 @@
-export * from './prefix'
-export * from './transformers'
-export * from './validation'
+export * from './prefix.js'
+export * from './transformers.js'
+export * from './validation.js'

--- a/src/did/prefix.ts
+++ b/src/did/prefix.ts
@@ -1,5 +1,5 @@
 import * as uint8arrays from 'uint8arrays'
-import { KeyType } from "../types"
+import { KeyType } from "../types.js"
 
 
 export const EDWARDS_DID_PREFIX = new Uint8Array([ 0xed, 0x01 ])

--- a/src/did/transformers.ts
+++ b/src/did/transformers.ts
@@ -1,7 +1,7 @@
 import * as uint8arrays from "uint8arrays"
 
-import { BASE58_DID_PREFIX, magicBytes, parseMagicBytes } from "./prefix"
-import { KeyType, Encodings } from "../types"
+import { BASE58_DID_PREFIX, magicBytes, parseMagicBytes } from "./prefix.js"
+import { KeyType, Encodings } from "../types.js"
 
 /**
  * Convert a public key in bytes to a DID (did:key).

--- a/src/did/validation.ts
+++ b/src/did/validation.ts
@@ -1,7 +1,7 @@
-import * as rsa from "../crypto/rsa"
+import * as rsa from "../crypto/rsa.js"
 import nacl from "tweetnacl"
 import * as uint8arrays from "uint8arrays"
-import { didToPublicKeyBytes } from "./transformers"
+import { didToPublicKeyBytes } from "./transformers.js"
 
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-export * from './token'
-export * from './did'
-export * as keypair from './keypair'
-export * from './keypair/ed25519'
-export * from './keypair/rsa'
-export * from './types'
+export * from './token.js'
+export * from './did/index.js'
+export * as keypair from './keypair/index.js'
+export * from './keypair/ed25519.js'
+export * from './keypair/rsa.js'
+export * from './types.js'
+

--- a/src/keypair/base.ts
+++ b/src/keypair/base.ts
@@ -1,6 +1,6 @@
 import * as uint8arrays from 'uint8arrays'
-import { publicKeyBytesToDid } from '../did/transformers'
-import { Keypair, KeyType, Encodings, Didable, ExportableKey } from '../types'
+import { publicKeyBytesToDid } from '../did/transformers.js'
+import { Keypair, KeyType, Encodings, Didable, ExportableKey } from '../types.js'
 
 export default abstract class BaseKeypair implements Keypair, Didable, ExportableKey {
 

--- a/src/keypair/ed25519.ts
+++ b/src/keypair/ed25519.ts
@@ -1,7 +1,7 @@
 import nacl from 'tweetnacl'
 import * as uint8arrays from 'uint8arrays'
-import BaseKeypair from './base'
-import { Encodings, KeyType } from '../types'
+import BaseKeypair from './base.js'
+import { Encodings, KeyType } from '../types.js'
 
 export class EdKeypair extends BaseKeypair {
 

--- a/src/keypair/index.ts
+++ b/src/keypair/index.ts
@@ -1,3 +1,3 @@
-export * from './ed25519'
-export * from './rsa'
-export * from './base'
+export * from './ed25519.js'
+export * from './rsa.js'
+export * from './base.js'

--- a/src/keypair/rsa.ts
+++ b/src/keypair/rsa.ts
@@ -1,6 +1,6 @@
-import * as rsa  from '../crypto/rsa'
-import BaseKeypair from './base'
-import { Encodings } from '../types'
+import * as rsa  from '../crypto/rsa.js'
+import BaseKeypair from './base.js'
+import { Encodings } from '../types.js'
 
 export class RsaKeypair extends BaseKeypair {
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,9 +1,9 @@
 import * as uint8arrays from 'uint8arrays'
-import * as base64 from "./base64"
-import * as util from './util'
-import * as did from './did'
-import { verifySignature } from "./did/validation"
-import { validAttenuation } from './attenuation'
+import * as base64 from "./base64.js"
+import * as util from './util.js'
+import * as did from './did/index.js'
+import { verifySignature } from "./did/validation.js"
+import { validAttenuation } from './attenuation.js'
 import { Keypair, KeyType, Capability, Fact, Ucan, UcanHeader, UcanPayload } from "./types"
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,24 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "target": "ES2018",
+    "module":"ESNext",
+    "lib": ["dom", "es2021"],
+    "sourceMap": true,
     "declaration": true,
-    "outDir": "dist",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
     "declarationDir": "dist",
-    "resolveJsonModule": true
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
   },
   "include": [
-    "src/index.ts"
+    "src/**/*"
   ],
+  "exlcude": [
+    "tests/**/*"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,11 @@ jest-snapshot@^27.2.0:
     pretty-format "^27.2.0"
     semver "^7.3.2"
 
+jest-ts-webcompat-resolver@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz#a554eb77446e1a8d2aabb810d6302bffaa00095c"
+  integrity sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==
+
 jest-util@^27.0.0, jest-util@^27.2.0:
   version "27.2.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.2.0.tgz#bfccb85cfafae752257319e825a5b8d4ada470dc"


### PR DESCRIPTION
This PR updates the build to support more bundlers and environments. It mostly imitates what we've found to work in [webnative](https://github.com/fission-suite/webnative) and [keystore-idb](https://github.com/fission-suite/keystore-idb).

With these changes, `ucan` will work with:

- Node (using ES modules and `import` syntax)
- Webpack 5
- Vite
- Parcel 2
- Snowpack
- Estrella
- SvelteKit (mostly, some issues remain but maybe with SvelteKit itself)

The package is changed to a module and export maps are added to `package.json`. Changing to a module makes Jest fail without changing the config file to a `.cjs` file.

The noisiest change is changing all of the imports and exports everywhere to use file extensions. This helps in `node` which has trouble resolving the imports and exports without file extensions. `jest-ts-webcompat-resolver` was added to help Jest with the `.js` file extensions.

The `tsconfig` mostly copies the config from `webnative`, but I kept `esModuleInterop` and `resolveJsonModule` set to `true`. Some of the Jest tests have issues without `esModuleInterop`.

### Testing

I tested the changes with our [React TodoMVC](https://github.com/fission-suite/react-todomvc) app and with [webnative-bundler-test](https://github.com/fission-suite/webnative-bundler-test). I also wrote a super simple little `node` test that imports and logs `ucan` like this

```javascript
import * as ucan from 'ucans'

console.log('ucan', ucan)
```