### PR TITLE
Add too early validator

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -186,6 +186,15 @@ export function isExpired(ucan: Ucan): boolean {
 }
 
 /**
+ * Check if a UCAN is not valid yet.
+ *
+ * @param ucan The UCAN to validate
+ */
+export const isNotValidYet = (ucan: Ucan): boolean => {
+  return ucan.payload.nbf > Math.floor(Date.now() / 1000)
+}
+
+/**
  * Check if a UCAN is valid.
  *
  * @param ucan The decoded UCAN

--- a/src/token.ts
+++ b/src/token.ts
@@ -186,11 +186,11 @@ export function isExpired(ucan: Ucan): boolean {
 }
 
 /**
- * Check if a UCAN is not valid yet.
+ * Check if a UCAN is not active yet.
  *
  * @param ucan The UCAN to validate
  */
-export const isNotValidYet = (ucan: Ucan): boolean => {
+export const isTooEarly = (ucan: Ucan): boolean => {
   return ucan.payload.nbf > Math.floor(Date.now() / 1000)
 }
 

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -86,4 +86,18 @@ describe('token', () => {
     const isValid = await token.isValid(childUcan)
     expect(isValid).toBe(false)
   })
+
+  it('identifies a ucan that is not valid yet', async () => {
+    const badUcan = {
+      ...ucan,
+      payload: {
+        ...ucan.payload,
+        nbf: 2637252774,
+        exp: 2637352774
+      }
+    }
+
+    const isNotValidYet = await token.isNotValidYet(badUcan)
+    expect(isNotValidYet).toBe(true)
+  })
 })

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -87,7 +87,7 @@ describe('token', () => {
     expect(isValid).toBe(false)
   })
 
-  it('identifies a ucan that is not valid yet', async () => {
+  it('identifies a ucan that is not active yet', async () => {
     const badUcan = {
       ...ucan,
       payload: {
@@ -97,7 +97,7 @@ describe('token', () => {
       }
     }
 
-    const isNotValidYet = await token.isNotValidYet(badUcan)
-    expect(isNotValidYet).toBe(true)
+    const isTooEarly = await token.isTooEarly(badUcan)
+    expect(isTooEarly).toBe(true)
   })
 })

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -100,4 +100,18 @@ describe('token', () => {
     const isTooEarly = await token.isTooEarly(badUcan)
     expect(isTooEarly).toBe(true)
   })
+
+  it('identifies a ucan that has become active', async () => {
+    const activeUcan = {
+      ...ucan,
+      payload: {
+        ...ucan.payload,
+        nbf: Math.floor(Date.now() / 1000),
+        lifetimeInSeonds: 30
+      }
+    }
+
+    const isTooEarly = await token.isTooEarly(activeUcan)
+    expect(isTooEarly).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add `isTooEarly` helper function

The `isTooEarly` helper checks if a UCAN is not valid yet by comparing `nbf` with the time when the check is made.

## Test plan (required)

A test case has been added to `tests/token.test.ts`.

