### PR TITLE
Remove padding on token

### DIFF
--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,11 +1,11 @@
 import * as uint8arrays from "uint8arrays"
 import { Encodings } from "./types"
 
-export function decode(base64: string, encoding: Encodings = 'base64pad'): string {
+export function decode(base64: string, encoding: Encodings = 'base64'): string {
   return uint8arrays.toString(uint8arrays.fromString(base64, encoding))
 }
 
-export function encode(str: string, encoding: Encodings = 'base64pad'): string {
+export function encode(str: string, encoding: Encodings = 'base64'): string {
   return uint8arrays.toString(uint8arrays.fromString(str), encoding)
 }
 


### PR DESCRIPTION
JWTs are bas64url encoded which implies no padding. If you look around, jwts in the wild don't have padding. And the jwt library that qri's go ucan implementation uses (https://github.com/golang-jwt/jwt) throws an error on tokens with padding.

I left the padding on keys because I feel like I normally see 64 keys include padding :thinking: thoughts?