### PR TITLE
Fix verify signature utf8

### DIFF
--- a/src/did/validation.ts
+++ b/src/did/validation.ts
@@ -32,7 +32,7 @@ export async function verifySignature(data: Uint8Array, signature: Uint8Array, d
  * Verify the signature of some data (string encoded as utf8), given a DID.
  */
 export async function verifySignatureUtf8(data: string, signature: string, did: string): Promise<boolean> {
-  const dataBytes = uint8arrays.fromString(data)
-  const sigBytes = uint8arrays.fromString(signature)
+  const dataBytes = uint8arrays.fromString(data, "utf8")
+  const sigBytes = uint8arrays.fromString(signature, "base64url")
   return await verifySignature(dataBytes, sigBytes, did)
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,7 +1,7 @@
 import * as uint8arrays from "uint8arrays"
 import * as util from "./util"
 import * as did from "./did"
-import { verifySignature } from "./did/validation"
+import { verifySignatureUtf8 } from "./did/validation"
 import { Keypair, KeyType, Capability, Fact, Ucan, UcanHeader, UcanPayload, isUcanHeader, isUcanPayload } from "./types"
 
 /**
@@ -214,9 +214,7 @@ export async function validate(encodedUcan: string, options?: ValidateOptions): 
   }
 
   if (checkSignature) {
-    const data = uint8arrays.fromString(`${encodedHeader}.${encodedPayload}`, "utf8")
-    const sig = uint8arrays.fromString(signature, "base64url")
-    if (!await verifySignature(data, sig, payload.iss)) {
+    if (!await verifySignatureUtf8(`${encodedHeader}.${encodedPayload}`, signature, payload.iss)) {
       throw new Error(`Invalid UCAN: ${encodedUcan}: Signature invalid.`)
     }
   }

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -1,4 +1,5 @@
 import * as token from "../src/token"
+import { verifySignatureUtf8 } from "../src/did"
 import { alice, bob } from "./fixtures"
 
 
@@ -67,4 +68,16 @@ describe("token.validate", () => {
     }
     expect(token.isTooEarly(activeUcan)).toBe(false)
   })
+})
+
+describe("verifySignatureUtf8", () => {
+  
+  it("works with an example", async () => {
+    const [header, payload, signature] = token.encode(await token.build({
+      issuer: alice,
+      audience: bob.did(),
+    })).split(".")
+    expect(await verifySignatureUtf8(`${header}.${payload}`, signature, alice.did())).toEqual(true)
+  })
+
 })


### PR DESCRIPTION
We need to decode the signature as base64url, not utf8 (the default).

Also added a regression test