### PR TITLE
Support WebCrypto ECDSA

### DIFF
--- a/src/crypto/ecdsa.ts
+++ b/src/crypto/ecdsa.ts
@@ -25,7 +25,7 @@ export const exportKey = async (key: CryptoKey): Promise<Uint8Array> => {
 
 export const importKey = async (
   key: Uint8Array,
-  namedCurve: NamedCurve = DEFAULT_CURVE
+  namedCurve: NamedCurve
 ): Promise<CryptoKey> => {
   return await webcrypto.subtle.importKey(
     "spki",
@@ -51,11 +51,12 @@ export const sign = async (
 export const verify = async (
   msg: Uint8Array,
   sig: Uint8Array,
-  pubKey: Uint8Array
+  pubKey: Uint8Array,
+  namedCurve: NamedCurve
 ): Promise<boolean> => {
   return await webcrypto.subtle.verify(
     { name: ALG, hash: { name: DEFAULT_HASH_ALG } },
-    await importKey(pubKey),
+    await importKey(pubKey, namedCurve),
     sig.buffer,
     msg.buffer
   )

--- a/src/crypto/ecdsa.ts
+++ b/src/crypto/ecdsa.ts
@@ -1,0 +1,75 @@
+import { webcrypto } from "one-webcrypto"
+import { NamedCurve, KeyType } from "../types"
+
+export const ALG = "ECDSA"
+export const DEFAULT_CURVE = "P-256"
+export const DEFAULT_HASH_ALG = "SHA-256"
+
+export const generateKeypair = async (
+  namedCurve: NamedCurve = DEFAULT_CURVE
+): Promise<CryptoKeyPair> => {
+  return await webcrypto.subtle.generateKey(
+    {
+      name: ALG,
+      namedCurve,
+    },
+    false,
+    ["sign", "verify"]
+  )
+}
+
+export const exportKey = async (key: CryptoKey): Promise<Uint8Array> => {
+  const buf = await webcrypto.subtle.exportKey("spki", key)
+  return new Uint8Array(buf)
+}
+
+export const importKey = async (
+  key: Uint8Array,
+  namedCurve: NamedCurve = DEFAULT_CURVE
+): Promise<CryptoKey> => {
+  return await webcrypto.subtle.importKey(
+    "spki",
+    key.buffer,
+    { name: ALG, namedCurve },
+    true,
+    ["verify"]
+  )
+}
+
+export const sign = async (
+  msg: Uint8Array,
+  privateKey: CryptoKey
+): Promise<Uint8Array> => {
+  const buf = await webcrypto.subtle.sign(
+    { name: ALG, hash: { name: DEFAULT_HASH_ALG } },
+    privateKey,
+    msg.buffer
+  )
+  return new Uint8Array(buf)
+}
+
+export const verify = async (
+  msg: Uint8Array,
+  sig: Uint8Array,
+  pubKey: Uint8Array
+): Promise<boolean> => {
+  return await webcrypto.subtle.verify(
+    { name: ALG, hash: { name: DEFAULT_HASH_ALG } },
+    await importKey(pubKey),
+    sig.buffer,
+    msg.buffer
+  )
+}
+
+export const toKeyType = (namedCurve: NamedCurve): KeyType => {
+  switch (namedCurve) {
+    case "P-256":
+      return "p256"
+    case "P-384":
+      return "p384"
+    case "P-521":
+      return "p521"
+    default:
+      throw new Error(`Unsupported namedCurve: ${namedCurve}`)
+  }
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,1 +1,2 @@
 export * as rsa from "./rsa"
+export * as ecdsa from "./ecdsa"

--- a/src/crypto/rsa.ts
+++ b/src/crypto/rsa.ts
@@ -55,16 +55,16 @@ export const verify = async (msg: Uint8Array, sig: Uint8Array, pubKey: Uint8Arra
 /**
  * The ASN.1 DER encoded header that needs to be added to an
  * ASN.1 DER encoded RSAPublicKey to make it a SubjectPublicKeyInfo.
- * 
+ *
  * This byte sequence is always the same.
- * 
+ *
  * A human-readable version of this as part of a dumpasn1 dump:
- * 
+ *
  *     SEQUENCE {
  *       OBJECT IDENTIFIER rsaEncryption (1 2 840 113549 1 1 1)
  *       NULL
  *     }
- * 
+ *
  * See https://github.com/ucan-wg/ts-ucan/issues/30
  */
 const SPKI_PARAMS_ENCODED = new Uint8Array([48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 1, 5, 0])
@@ -152,17 +152,17 @@ function asn1Skip(input: Uint8Array, expectedTag: Uint8Array, position: number):
 }
 
 function asn1Into(input: Uint8Array, expectedTag: Uint8Array, position: number): { position: number; length: number } {
-    // tag
-    const lengthPos = position + expectedTag.length
-    const actualTag = input.subarray(position, lengthPos)
-    if (!uint8arrays.equals(actualTag, expectedTag)) {
-      throw new Error(`ASN parsing error: Expected tag 0x${uint8arrays.toString(expectedTag, "hex")} at position ${position}, but got ${uint8arrays.toString(actualTag, "hex")}.`)
-    }
-    
-    // length
-    const length = asn1DERLengthDecodeWithConsumed(input.subarray(lengthPos/*, we don't know the end */))
-    const contentPos = position + 1 + length.consumed
-    
-    // content
-    return { position: contentPos, length: length.number }
+  // tag
+  const lengthPos = position + expectedTag.length
+  const actualTag = input.subarray(position, lengthPos)
+  if (!uint8arrays.equals(actualTag, expectedTag)) {
+    throw new Error(`ASN parsing error: Expected tag 0x${uint8arrays.toString(expectedTag, "hex")} at position ${position}, but got ${uint8arrays.toString(actualTag, "hex")}.`)
+  }
+
+  // length
+  const length = asn1DERLengthDecodeWithConsumed(input.subarray(lengthPos/*, we don't know the end */))
+  const contentPos = position + 1 + length.consumed
+
+  // content
+  return { position: contentPos, length: length.number }
 }

--- a/src/did/prefix.ts
+++ b/src/did/prefix.ts
@@ -1,7 +1,6 @@
 import * as uint8arrays from "uint8arrays"
 import { KeyType } from "../types"
 
-
 // Each prefix is varint-encoded. So e.g. 0x1205 gets varint-encoded to 0x8524
 // The varint encoding is described here: https://github.com/multiformats/unsigned-varint
 // These varints are encoded big-endian in 7-bit pieces.
@@ -10,26 +9,41 @@ import { KeyType } from "../types"
 // The next 7 bits encode as 0x24 (instead of 0x12) => 0x8524
 
 /** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L94 */
-export const EDWARDS_DID_PREFIX = new Uint8Array([ 0xed, 0x01 ])
+export const EDWARDS_DID_PREFIX = new Uint8Array([0xed, 0x01])
 /** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L91 */
-export const BLS_DID_PREFIX = new Uint8Array([ 0xea, 0x01 ])
+export const BLS_DID_PREFIX = new Uint8Array([0xea, 0x01])
+/** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L141 */
+export const P256_DID_PREFIX = new Uint8Array([0x80, 0x24])
+/** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L142 */
+export const P384_DID_PREFIX = new Uint8Array([0x81, 0x24])
+/** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L143 */
+export const P521_DID_PREFIX = new Uint8Array([0x82, 0x24])
 /** https://github.com/multiformats/multicodec/blob/e9ecf587558964715054a0afcc01f7ace220952c/table.csv#L146 */
-export const RSA_DID_PREFIX = new Uint8Array([ 0x85, 0x24 ])
+export const RSA_DID_PREFIX = new Uint8Array([0x85, 0x24])
 /** Old RSA DID prefix, used pre-standardisation */
-export const RSA_DID_PREFIX_OLD = new Uint8Array([ 0x00, 0xf5, 0x02 ])
+export const RSA_DID_PREFIX_OLD = new Uint8Array([0x00, 0xf5, 0x02])
 
 export const BASE58_DID_PREFIX = "did:key:z" // z is the multibase prefix for base58btc byte encoding
-
 
 /**
  * Magic bytes.
  */
 export function magicBytes(keyType: KeyType): Uint8Array | null {
   switch (keyType) {
-    case "ed25519": return EDWARDS_DID_PREFIX
-    case "rsa": return RSA_DID_PREFIX
-    case "bls12-381": return BLS_DID_PREFIX
-    default: return null
+    case "ed25519":
+      return EDWARDS_DID_PREFIX
+    case "p256":
+      return P256_DID_PREFIX
+    case "p384":
+      return P384_DID_PREFIX
+    case "p521":
+      return P521_DID_PREFIX
+    case "rsa":
+      return RSA_DID_PREFIX
+    case "bls12-381":
+      return BLS_DID_PREFIX
+    default:
+      return null
   }
 }
 
@@ -37,7 +51,9 @@ export function magicBytes(keyType: KeyType): Uint8Array | null {
  * Parse magic bytes on prefixed key-bytes
  * to determine cryptosystem & the unprefixed key-bytes.
  */
-export const parseMagicBytes = (prefixedKey: Uint8Array): {
+export const parseMagicBytes = (
+  prefixedKey: Uint8Array
+): {
   keyBytes: Uint8Array
   type: KeyType
 } => {
@@ -45,28 +61,49 @@ export const parseMagicBytes = (prefixedKey: Uint8Array): {
   if (hasPrefix(prefixedKey, RSA_DID_PREFIX)) {
     return {
       keyBytes: prefixedKey.slice(RSA_DID_PREFIX.byteLength),
-      type: "rsa"
+      type: "rsa",
     }
 
-  // RSA OLD
+    // RSA OLD
   } else if (hasPrefix(prefixedKey, RSA_DID_PREFIX_OLD)) {
     return {
       keyBytes: prefixedKey.slice(RSA_DID_PREFIX_OLD.byteLength),
-      type: "rsa"
+      type: "rsa",
     }
 
-  // EDWARDS
+    // EC P-256
+  } else if (hasPrefix(prefixedKey, P256_DID_PREFIX)) {
+    return {
+      keyBytes: prefixedKey.slice(P256_DID_PREFIX.byteLength),
+      type: "p256",
+    }
+
+    // EC P-384
+  } else if (hasPrefix(prefixedKey, P384_DID_PREFIX)) {
+    return {
+      keyBytes: prefixedKey.slice(P384_DID_PREFIX.byteLength),
+      type: "p384",
+    }
+
+    // EC P-521
+  } else if (hasPrefix(prefixedKey, P521_DID_PREFIX)) {
+    return {
+      keyBytes: prefixedKey.slice(P521_DID_PREFIX.byteLength),
+      type: "p521",
+    }
+
+    // EDWARDS
   } else if (hasPrefix(prefixedKey, EDWARDS_DID_PREFIX)) {
     return {
       keyBytes: prefixedKey.slice(EDWARDS_DID_PREFIX.byteLength),
-      type: "ed25519"
+      type: "ed25519",
     }
 
-  // BLS
+    // BLS
   } else if (hasPrefix(prefixedKey, BLS_DID_PREFIX)) {
     return {
       keyBytes: prefixedKey.slice(BLS_DID_PREFIX.byteLength),
-      type: "bls12-381"
+      type: "bls12-381",
     }
   }
 
@@ -76,6 +113,9 @@ export const parseMagicBytes = (prefixedKey: Uint8Array): {
 /**
  * Determines if a Uint8Array has a given indeterminate length-prefix.
  */
-export const hasPrefix = (prefixedKey: Uint8Array, prefix: Uint8Array): boolean => {
+export const hasPrefix = (
+  prefixedKey: Uint8Array,
+  prefix: Uint8Array
+): boolean => {
   return uint8arrays.equals(prefix, prefixedKey.subarray(0, prefix.byteLength))
 }

--- a/src/did/validation.ts
+++ b/src/did/validation.ts
@@ -23,9 +23,13 @@ export async function verifySignature(data: Uint8Array, signature: Uint8Array, d
         return await rsa.verify(data, signature, publicKey)
 
       case "p256":
+        return await ecdsa.verify(data, signature, publicKey, "P-256")
+
       case "p384":
+        return await ecdsa.verify(data, signature, publicKey, "P-384")
+
       case "p521":
-        return await ecdsa.verify(data, signature, publicKey)
+        return await ecdsa.verify(data, signature, publicKey, "P-521")
 
       default: return false
     }

--- a/src/did/validation.ts
+++ b/src/did/validation.ts
@@ -2,6 +2,8 @@ import * as uint8arrays from "uint8arrays"
 import nacl from "tweetnacl"
 
 import * as rsa from "../crypto/rsa"
+import * as ecdsa from "../crypto/ecdsa"
+
 import { didToPublicKeyBytes } from "./transformers"
 
 
@@ -19,6 +21,11 @@ export async function verifySignature(data: Uint8Array, signature: Uint8Array, d
 
       case "rsa":
         return await rsa.verify(data, signature, publicKey)
+
+      case "p256":
+      case "p384":
+      case "p521":
+        return await ecdsa.verify(data, signature, publicKey)
 
       default: return false
     }

--- a/src/keypair/ecdsa.ts
+++ b/src/keypair/ecdsa.ts
@@ -1,0 +1,56 @@
+import { webcrypto } from "one-webcrypto"
+import * as uint8arrays from "uint8arrays"
+import * as ecdsa from "../crypto/ecdsa"
+import {
+  AvailableCryptoKeyPair,
+  Encodings,
+  isAvailableCryptoKeyPair,
+  NamedCurve,
+} from "../types"
+import BaseKeypair from "./base"
+
+export class EcdsaKeypair extends BaseKeypair {
+  private keypair: AvailableCryptoKeyPair
+
+  constructor(
+    keypair: AvailableCryptoKeyPair,
+    publicKey: Uint8Array,
+    namedCurve: NamedCurve,
+    exportable: boolean
+  ) {
+    super(publicKey, ecdsa.toKeyType(namedCurve), exportable)
+    this.keypair = keypair
+  }
+
+  static async create(params?: {
+    namedCurve?: NamedCurve
+    exportable?: boolean
+  }): Promise<EcdsaKeypair> {
+    const { namedCurve = "P-256", exportable = false } = params || {}
+    const keypair = await ecdsa.generateKeypair(namedCurve)
+
+    if (!isAvailableCryptoKeyPair(keypair)) {
+      throw new Error(`Couldn't generate valid keypair`)
+    }
+
+    const publicKey = await ecdsa.exportKey(keypair.publicKey)
+    return new EcdsaKeypair(keypair, publicKey, namedCurve, exportable)
+  }
+
+  async sign(msg: Uint8Array): Promise<Uint8Array> {
+    return await ecdsa.sign(msg, this.keypair.privateKey)
+  }
+
+  async export(format: Encodings = "base64pad"): Promise<string> {
+    if (!this.exportable) {
+      throw new Error("Key is not exportable")
+    }
+    const arrayBuffer = await webcrypto.subtle.exportKey(
+      "pkcs8",
+      this.keypair.privateKey
+    )
+    return uint8arrays.toString(new Uint8Array(arrayBuffer), format)
+  }
+}
+
+export default EcdsaKeypair

--- a/src/keypair/index.ts
+++ b/src/keypair/index.ts
@@ -1,3 +1,4 @@
 export * from "./ed25519"
+export * from "./ecdsa"
 export * from "./rsa"
 export * from "./base"

--- a/src/keypair/rsa.ts
+++ b/src/keypair/rsa.ts
@@ -1,7 +1,7 @@
 import { webcrypto } from "one-webcrypto"
 import * as uint8arrays from "uint8arrays"
 
-import * as rsa  from "../crypto/rsa"
+import * as rsa from "../crypto/rsa"
 import BaseKeypair from "./base"
 import { Encodings, AvailableCryptoKeyPair, isAvailableCryptoKeyPair } from "../types"
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import { SupportedEncodings } from "uint8arrays/util/bases"
 import * as util from "./util"
 
-
 export type Encodings = SupportedEncodings
 
 export interface Keypair {
@@ -25,7 +24,16 @@ export interface ExportableKey {
   export: (format?: Encodings) => Promise<string>
 }
 
-export type KeyType = "rsa" | "ed25519" | "bls12-381"
+export type KeyType =
+  | "rsa"
+  | "p256"
+  | "p384"
+  | "p521"
+  | "ed25519"
+  | "bls12-381"
+
+// https://developer.mozilla.org/en-US/docs/Web/API/EcKeyGenParams
+export type NamedCurve = "P-256" | "P-384" | "P-521"
 
 export type Fact = Record<string, unknown>
 
@@ -62,41 +70,64 @@ export type Ucan<Prf = string> = {
   signature: string
 }
 
-
-
 // TYPE CHECKS
 
-
 export function isUcanHeader(obj: unknown): obj is UcanHeader {
-  return util.isRecord(obj)
-    && util.hasProp(obj, "alg") && typeof obj.alg === "string"
-    && util.hasProp(obj, "typ") && typeof obj.typ === "string"
-    && util.hasProp(obj, "ucv") && typeof obj.ucv === "string"
+  return (
+    util.isRecord(obj) &&
+    util.hasProp(obj, "alg") &&
+    typeof obj.alg === "string" &&
+    util.hasProp(obj, "typ") &&
+    typeof obj.typ === "string" &&
+    util.hasProp(obj, "ucv") &&
+    typeof obj.ucv === "string"
+  )
 }
 
 export function isUcanPayload(obj: unknown): obj is UcanPayload {
-  return util.isRecord(obj)
-    && util.hasProp(obj, "iss") && typeof obj.iss === "string"
-    && util.hasProp(obj, "aud") && typeof obj.aud === "string"
-    && util.hasProp(obj, "exp") && typeof obj.exp === "number"
-    && (!util.hasProp(obj, "nbf") || typeof obj.nbf === "number")
-    && (!util.hasProp(obj, "nnc") || typeof obj.nnc === "string")
-    && util.hasProp(obj, "att") && Array.isArray(obj.att) && obj.att.every(isCapability)
-    && (!util.hasProp(obj, "fct") || Array.isArray(obj.fct) && obj.fct.every(util.isRecord))
-    && util.hasProp(obj, "prf") && Array.isArray(obj.prf) && obj.prf.every(str => typeof str === "string")
+  return (
+    util.isRecord(obj) &&
+    util.hasProp(obj, "iss") &&
+    typeof obj.iss === "string" &&
+    util.hasProp(obj, "aud") &&
+    typeof obj.aud === "string" &&
+    util.hasProp(obj, "exp") &&
+    typeof obj.exp === "number" &&
+    (!util.hasProp(obj, "nbf") || typeof obj.nbf === "number") &&
+    (!util.hasProp(obj, "nnc") || typeof obj.nnc === "string") &&
+    util.hasProp(obj, "att") &&
+    Array.isArray(obj.att) &&
+    obj.att.every(isCapability) &&
+    (!util.hasProp(obj, "fct") ||
+      (Array.isArray(obj.fct) && obj.fct.every(util.isRecord))) &&
+    util.hasProp(obj, "prf") &&
+    Array.isArray(obj.prf) &&
+    obj.prf.every((str) => typeof str === "string")
+  )
 }
 
 export function isCapability(obj: unknown): obj is Capability {
-  return util.isRecord(obj) && util.hasProp(obj, "cap") && typeof obj.cap === "string"
+  return (
+    util.isRecord(obj) &&
+    util.hasProp(obj, "cap") &&
+    typeof obj.cap === "string"
+  )
 }
 
-export function isAvailableCryptoKeyPair(keypair: CryptoKeyPair): keypair is AvailableCryptoKeyPair {
+export function isAvailableCryptoKeyPair(
+  keypair: CryptoKeyPair
+): keypair is AvailableCryptoKeyPair {
   return keypair.publicKey != null && keypair.privateKey != null
 }
 
 export function isKeypair(obj: unknown): obj is Keypair {
-  return util.isRecord(obj)
-    && util.hasProp(obj, "publicKey") && obj.publicKey instanceof Uint8Array
-    && util.hasProp(obj, "keyType") && typeof obj.keyType === "string"
-    && util.hasProp(obj, "sign") && typeof obj.sign === "function"
+  return (
+    util.isRecord(obj) &&
+    util.hasProp(obj, "publicKey") &&
+    obj.publicKey instanceof Uint8Array &&
+    util.hasProp(obj, "keyType") &&
+    typeof obj.keyType === "string" &&
+    util.hasProp(obj, "sign") &&
+    typeof obj.sign === "function"
+  )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,64 +70,41 @@ export type Ucan<Prf = string> = {
   signature: string
 }
 
+
+
 // TYPE CHECKS
 
+
 export function isUcanHeader(obj: unknown): obj is UcanHeader {
-  return (
-    util.isRecord(obj) &&
-    util.hasProp(obj, "alg") &&
-    typeof obj.alg === "string" &&
-    util.hasProp(obj, "typ") &&
-    typeof obj.typ === "string" &&
-    util.hasProp(obj, "ucv") &&
-    typeof obj.ucv === "string"
-  )
+  return util.isRecord(obj)
+    && util.hasProp(obj, "alg") && typeof obj.alg === "string"
+    && util.hasProp(obj, "typ") && typeof obj.typ === "string"
+    && util.hasProp(obj, "ucv") && typeof obj.ucv === "string"
 }
 
 export function isUcanPayload(obj: unknown): obj is UcanPayload {
-  return (
-    util.isRecord(obj) &&
-    util.hasProp(obj, "iss") &&
-    typeof obj.iss === "string" &&
-    util.hasProp(obj, "aud") &&
-    typeof obj.aud === "string" &&
-    util.hasProp(obj, "exp") &&
-    typeof obj.exp === "number" &&
-    (!util.hasProp(obj, "nbf") || typeof obj.nbf === "number") &&
-    (!util.hasProp(obj, "nnc") || typeof obj.nnc === "string") &&
-    util.hasProp(obj, "att") &&
-    Array.isArray(obj.att) &&
-    obj.att.every(isCapability) &&
-    (!util.hasProp(obj, "fct") ||
-      (Array.isArray(obj.fct) && obj.fct.every(util.isRecord))) &&
-    util.hasProp(obj, "prf") &&
-    Array.isArray(obj.prf) &&
-    obj.prf.every((str) => typeof str === "string")
-  )
+  return util.isRecord(obj)
+    && util.hasProp(obj, "iss") && typeof obj.iss === "string"
+    && util.hasProp(obj, "aud") && typeof obj.aud === "string"
+    && util.hasProp(obj, "exp") && typeof obj.exp === "number"
+    && (!util.hasProp(obj, "nbf") || typeof obj.nbf === "number")
+    && (!util.hasProp(obj, "nnc") || typeof obj.nnc === "string")
+    && util.hasProp(obj, "att") && Array.isArray(obj.att) && obj.att.every(isCapability)
+    && (!util.hasProp(obj, "fct") || Array.isArray(obj.fct) && obj.fct.every(util.isRecord))
+    && util.hasProp(obj, "prf") && Array.isArray(obj.prf) && obj.prf.every(str => typeof str === "string")
 }
 
 export function isCapability(obj: unknown): obj is Capability {
-  return (
-    util.isRecord(obj) &&
-    util.hasProp(obj, "cap") &&
-    typeof obj.cap === "string"
-  )
+  return util.isRecord(obj) && util.hasProp(obj, "cap") && typeof obj.cap === "string"
 }
 
-export function isAvailableCryptoKeyPair(
-  keypair: CryptoKeyPair
-): keypair is AvailableCryptoKeyPair {
+export function isAvailableCryptoKeyPair(keypair: CryptoKeyPair): keypair is AvailableCryptoKeyPair {
   return keypair.publicKey != null && keypair.privateKey != null
 }
 
 export function isKeypair(obj: unknown): obj is Keypair {
-  return (
-    util.isRecord(obj) &&
-    util.hasProp(obj, "publicKey") &&
-    obj.publicKey instanceof Uint8Array &&
-    util.hasProp(obj, "keyType") &&
-    typeof obj.keyType === "string" &&
-    util.hasProp(obj, "sign") &&
-    typeof obj.sign === "function"
-  )
+  return util.isRecord(obj)
+    && util.hasProp(obj, "publicKey") && obj.publicKey instanceof Uint8Array
+    && util.hasProp(obj, "keyType") && typeof obj.keyType === "string"
+    && util.hasProp(obj, "sign") && typeof obj.sign === "function"
 }

--- a/tests/ecdsa.test.ts
+++ b/tests/ecdsa.test.ts
@@ -3,28 +3,72 @@ import ECDSAKeyPair from "../src/keypair/ecdsa"
 
 
 describe("ecdsa", () => {
-  let keypair: ECDSAKeyPair
-  let signature: Uint8Array
+
+  let p256Keypair: ECDSAKeyPair
+  let p384Keypair: ECDSAKeyPair
+  let p521Keypair: ECDSAKeyPair
+
+  let p256Signature: Uint8Array
+  let p384Signature: Uint8Array
+  let p521Signature: Uint8Array
+
   const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-  it("creates an ecdsa keypair", async () => {
-    keypair = await ECDSAKeyPair.create()
+  it("creates an ecdsa keypairs with different curves", async () => {
+    p256Keypair = await ECDSAKeyPair.create()
+    p384Keypair = await ECDSAKeyPair.create({ namedCurve: "P-384" })
+    p521Keypair = await ECDSAKeyPair.create({ namedCurve: "P-521" })
   })
 
-  it("returns a publicKeyStr and did", () => {
-    const publicKey = keypair.publicKeyStr()
-    const keyDid = keypair.did()
+  it("returns a publicKeyStr and did: curve P-256", () => {
+    const keyDid = p256Keypair.did()
+    const publicKey = p256Keypair.publicKeyStr()
     const transformed = did.didToPublicKey(keyDid)
     expect(transformed.publicKey).toEqual(publicKey)
     expect(transformed.type).toEqual("p256")
   })
 
-  it("signs data", async () => {
-    signature = await keypair.sign(data)
+  it("returns a publicKeyStr and did: curve P-384", async () => {
+    const publicKey = p384Keypair.publicKeyStr()
+    const keyDid = p384Keypair.did()
+    const transformed = did.didToPublicKey(keyDid)
+    expect(transformed.publicKey).toEqual(publicKey)
+    expect(transformed.type).toEqual("p384")
   })
 
-  it("can verify signature", async () => {
-    const isValid = await did.verifySignature(data, signature, keypair.did())
-    expect(isValid).toEqual(true)
+  it("returns a publicKeyStr and did: curve P-521", async () => {
+    const publicKey = p521Keypair.publicKeyStr()
+    const keyDid = p521Keypair.did()
+    const transformed = did.didToPublicKey(keyDid)
+    expect(transformed.publicKey).toEqual(publicKey)
+    expect(transformed.type).toEqual("p521")
   })
+
+  it("signs data: curve P-256", async () => {
+    p256Signature = await p256Keypair.sign(data)
+  })
+
+  it("signs data: curve P-384", async () => {
+    p384Signature = await p384Keypair.sign(data)
+  })
+
+  it("signs data: curve P-521", async () => {
+    p521Signature = await p521Keypair.sign(data)
+  })
+
+  it("can verify signature: P-256", async () => {
+    const isValid = await did.verifySignature(data, p256Signature, p256Keypair.did())
+    expect(isValid).toBeTruthy()
+  })
+
+  it("can verify signature: P-384", async () => {
+    const isValid = await did.verifySignature(data, p384Signature, p384Keypair.did())
+    expect(isValid).toBeTruthy()
+  })
+
+  it("can verify signature: P-521", async () => {
+    const isValid = await did.verifySignature(data, p521Signature, p521Keypair.did())
+    expect(isValid).toBeTruthy()
+  })
+
 })

--- a/tests/ecdsa.test.ts
+++ b/tests/ecdsa.test.ts
@@ -1,14 +1,14 @@
 import * as did from "../src/did"
-import EdwardsKey from "../src/keypair/ed25519"
+import ECDSAKeyPair from "../src/keypair/ecdsa"
 
-describe("ed25519", () => {
 
-  let keypair: EdwardsKey
+describe("ecdsa", () => {
+  let keypair: ECDSAKeyPair
   let signature: Uint8Array
-  const data = new Uint8Array([1,2,3,4,5,6,7,8,9])
+  const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-  it("creates an edwards keypair", async () => {
-    keypair = await EdwardsKey.create()
+  it("creates an ecdsa keypair", async () => {
+    keypair = await ECDSAKeyPair.create()
   })
 
   it("returns a publicKeyStr and did", () => {
@@ -16,7 +16,7 @@ describe("ed25519", () => {
     const keyDid = keypair.did()
     const transformed = did.didToPublicKey(keyDid)
     expect(transformed.publicKey).toEqual(publicKey)
-    expect(transformed.type).toEqual("ed25519")
+    expect(transformed.type).toEqual("p256")
   })
 
   it("signs data", async () => {
@@ -27,5 +27,4 @@ describe("ed25519", () => {
     const isValid = await did.verifySignature(data, signature, keypair.did())
     expect(isValid).toEqual(true)
   })
-
 })

--- a/tests/ed25519.test.ts
+++ b/tests/ed25519.test.ts
@@ -5,9 +5,9 @@ describe("ed25519", () => {
 
   let keypair: EdwardsKey
   let signature: Uint8Array
-  const data = new Uint8Array([1,2,3,4,5,6,7,8,9])
+  const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-  it("creates an edwards keypair", async () => {
+  it("creates an edwards curve keypair", async () => {
     keypair = await EdwardsKey.create()
   })
 


### PR DESCRIPTION
Fixes #48 

This extends UCAN's `did:key` method impl with ECDSA-based keys using NIST-approved curves (`P-256`, `P-384`, and `P-521`).
 
It currently leaves out `secp256k1` because [there is no plan to support it in WebCrypto API](https://github.com/w3c/webcrypto/issues/82). @dholms