### PR TITLE
Add missing pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,17 @@ const ucan = ucans.build({
   issuer: keypair,
   capabilities: [
     ucans.capability.my("resource"),
+    ucans.capability.parse({
+      with: "wnfs://boris.fission.name/public/photos/",
+      can: "wnfs/OVERWRITE"
+    }),
     {
-      with: ucans.capability.resourcePointer.parse("wnfs://boris.fission.name/public/photos/"),
-      can: ucans.capability.ability.parse("wnfs/OVERWRITE")
+      with: ucans.capability.resourcePointer.parse("wnfs://boris.fission.name/public/photos/vacation/"),
+      can: ucans.capability.ability.parse("wnfs/REVISE")
+    },
+    {
+      with: { scheme: "wnfs", hierPart: "//boris.fission.name/public/photos/vacation/" },
+      can: { namespace: "wnfs", segments: [ "REVISE" ] }
     }
   ]
 })
@@ -212,6 +220,21 @@ const result = ucans.hasCapability(
 
 if (result === false) log("UCAN does not have this capability 🚨")
 else log("UCAN has the capability ✅ Info:", result.info, "Capability:", result.capability)
+
+// Comparing capabilities
+const a = {
+  with: { scheme: "scheme", hierPart: "hierPart" },
+  can: { namespace: "namespace", segments: [ "a", "B" ] }
+}
+
+const b = {
+  with: { scheme: "SCHEME", hierPart: "hierPart" },
+  can: { namespace: "NAMESPACE", segments: [ "A", "b" ] }
+}
+
+ucans.capability.isEqual(a, b)
+ucans.capability.resourcePointer.isEqual(a.with, b.with)
+ucans.capability.ability.isEqual(a.can, b.can)
 ```
 
 

--- a/src/capability.ts
+++ b/src/capability.ts
@@ -75,6 +75,23 @@ export function prf(selector: Superuser | number, ability: Ability): Capability 
 
 
 
+// 🛠
+
+
+/**
+ * Check if two capabilities are equal.
+ *
+ * This is not the same as `JSON.stringify(capA) === JSON.stringify(capB)`.
+ * Specifically:
+ *   - For resource pointers, it does case-insensitive matching of the `scheme`.
+ *   - For abilities, it does case-insensitive matching of the namespace and segments.
+ */
+export function isEqual(a: Capability, b: Capability): boolean {
+  return resourcePointer.isEqual(a.with, b.with) && ability.isEqual(a.can, b.can)
+}
+
+
+
 // ENCODING
 
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,14 +1,14 @@
-import * as did from "./did"
 import * as uint8arrays from "uint8arrays"
 
+import * as capability from "./capability"
+import * as did from "./did"
 import * as util from "./util"
+import { Capability, isCapability, isEncodedCapability } from "./capability"
+import { Fact, KeyType, Keypair } from "./types"
+import { Ucan, UcanHeader, UcanParts, UcanPayload } from "./types"
 import { handleCompatibility } from "./compatibility"
 import { isUcanHeader, isUcanPayload } from "./types"
 import { verifySignatureUtf8 } from "./did/validation"
-import { Capability, isEncodedCapability } from "./capability"
-import { Fact, Keypair, KeyType } from "./types"
-import { Ucan, UcanHeader, UcanPayload, UcanParts } from "./types"
-import { capability, isCapability } from "."
 
 
 // CONSTANTS
@@ -196,16 +196,31 @@ export function encode(ucan: Ucan): string {
  * @returns The header of a UCAN encoded as url-safe base64 JSON
  */
 export function encodeHeader(header: UcanHeader): string {
-  return uint8arrays.toString(uint8arrays.fromString(JSON.stringify(header), "utf8"), "base64url")
+  return uint8arrays.toString(
+    uint8arrays.fromString(JSON.stringify(header), "utf8"),
+    "base64url"
+  )
 }
 
 /**
  * Encode the payload of a UCAN.
  *
+ * NOTE: This will encode capabilities as well, so that it matches the UCAN spec.
+ *       In other words, `{ with: { scheme, hierPart }, can: { namespace, segments } }`
+ *       becomes `{ with: "${scheme}:${hierPart}", can: "${namespace}/${segment}" }`
+ *
  * @param payload The UcanPayload to encode
  */
 export function encodePayload(payload: UcanPayload): string {
-  return uint8arrays.toString(uint8arrays.fromString(JSON.stringify(payload), "utf8"), "base64url")
+  const payloadWithEncodedCaps = {
+    ...payload,
+    capabilities: payload.att.map(capability.encode)
+  }
+
+  return uint8arrays.toString(
+    uint8arrays.fromString(JSON.stringify(payloadWithEncodedCaps), "utf8"),
+    "base64url"
+  )
 }
 
 /**

--- a/tests/capability.test.ts
+++ b/tests/capability.test.ts
@@ -1,0 +1,22 @@
+import * as capability from "../src/capability"
+
+
+describe("capability.isEqual", () => {
+
+  it("is able to compare two equal capabilities", () => {
+    const a = {
+      with: { scheme: "scheme", hierPart: "hierPart" },
+      can: { namespace: "namespace", segments: [ "a", "B" ] }
+    }
+
+    const b = {
+      with: { scheme: "SCHEME", hierPart: "hierPart" },
+      can: { namespace: "NAMESPACE", segments: [ "A", "b" ] }
+    }
+
+    expect(capability.isEqual(a, b)).toBe(true)
+    expect(capability.resourcePointer.isEqual(a.with, b.with)).toBe(true)
+    expect(capability.ability.isEqual(a.can, b.can)).toBe(true)
+  })
+
+})

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -1,3 +1,6 @@
+import * as uint8arrays from "uint8arrays"
+
+import * as capability from "../src/capability"
 import * as token from "../src/token"
 import { verifySignatureUtf8 } from "../src/did"
 import { alice, bob } from "./fixtures"
@@ -39,6 +42,42 @@ describe("token.build", () => {
         data => alice.sign(data)
       )
     }).rejects.toBeDefined()
+  })
+
+})
+
+
+
+// ENCODING
+
+
+describe("token.encodePayload", () => {
+
+  it("encodes capabilities", () => {
+    const encodedCaps = {
+      with: "wnfs://boris.fission.name/public/photos/",
+      can: "crud/DELETE"
+    }
+
+    const payload = token.buildPayload({
+      issuer: alice.did(),
+      audience: bob.did(),
+      capabilities: [ capability.parse(encodedCaps) ]
+    })
+
+    const encoded = token.encodePayload(payload)
+    const decodedString = uint8arrays.toString(
+      uint8arrays.fromString(encoded, "base64url"),
+      "utf8"
+    )
+
+    const decoded = JSON.parse(decodedString)
+
+    expect(
+      JSON.stringify(decoded.capabilities)
+    ).toEqual(
+      JSON.stringify([ encodedCaps ])
+    )
   })
 
 })


### PR DESCRIPTION
Missed a few things with the spec changes:
- Added more examples to the readme on how to create capabilities
- Explained in readme how to compare capabilities
- Added missing `capability.isEqual()`
- Forgot to encode capabilities when encoding UCANs
- Added some tests for the above