### PR TITLE
Allow redelegation in capability checking

### DIFF
--- a/src/attenuation.ts
+++ b/src/attenuation.ts
@@ -1,9 +1,9 @@
 // https://github.com/ucan-wg/spec/blob/dd4ac83f893cef109f5a26b07970b2484f23aabf/README.md#325-attenuation-scope
-import * as capability from "./capability"
-import * as util from "./util"
-import { Capability } from "./capability"
-import { Chained } from "./chained"
-import { Ucan } from "./types"
+import * as capability from "./capability/index.js"
+import * as util from "./util.js"
+import { Capability } from "./capability/index.js"
+import { Chained } from "./chained.js"
+import { Ucan } from "./types.js"
 
 
 // TYPES

--- a/src/attenuation.ts
+++ b/src/attenuation.ts
@@ -119,10 +119,9 @@ export function capabilities<A>(
     return function* () {
       for (const parsedChildCap of findParsingCaps(ucan)) {
         let isCoveredByProof = false
-        let proofIndex: null | number = null
+        let proofIndex = 0
 
         for (const capabilitiesInProof of capabilitiesInProofs()) {
-          proofIndex = proofIndex === null ? 0 : proofIndex + 1
           for (const parsedParentCap of capabilitiesInProof()) {
             // pass through capability escalations from parents
             if (isCapabilityEscalation(parsedParentCap)) {
@@ -170,7 +169,10 @@ export function capabilities<A>(
               }
             }
           }
+
+          proofIndex++
         }
+
         // If a capability can't be considered to be delegated by any of its proofs
         // (or if there are no proofs),
         // then we root its origin in the UCAN we're looking at.

--- a/src/attenuation.ts
+++ b/src/attenuation.ts
@@ -1,8 +1,9 @@
 // https://github.com/ucan-wg/spec/blob/dd4ac83f893cef109f5a26b07970b2484f23aabf/README.md#325-attenuation-scope
-import { Capability } from "./capability/index.js"
-import { Chained } from "./chained.js"
-import { Ucan } from "./types.js"
-import * as util from "./util.js"
+import * as capability from "./capability"
+import * as util from "./util"
+import { Capability } from "./capability"
+import { Chained } from "./chained"
+import { Ucan } from "./types"
 
 
 // TYPES
@@ -123,6 +124,16 @@ export function capabilities<A>(
             // pass through capability escalations from parents
             if (isCapabilityEscalation(parsedParentCap)) {
               yield parsedParentCap
+
+            } else if (
+              capability.isCapability(parsedChildCap.capability) &&
+              (
+                parsedChildCap.capability.with.scheme.toLowerCase() === "as" ||
+                parsedChildCap.capability.with.scheme.toLowerCase() === "my"
+              )
+            ) {
+              yield parsedParentCap
+
             } else {
               // try figuring out whether we can delegate the capabilities from this to the parent
               const delegated = semantics.tryDelegating(parsedParentCap.capability, parsedChildCap.capability)

--- a/src/capability/ability.ts
+++ b/src/capability/ability.ts
@@ -9,7 +9,18 @@ export type Ability
   = Superuser
   | { namespace: string; segments: string[] }
 
+
+/**
+ * Separator for an ability's segments.
+ */
 export const SEPARATOR: string = "/"
+
+
+/**
+ * Ability that can be used with a `prf` resource-pointer.
+ * This redelegates all capabilities of the proof(s).
+ */
+export const REDELEGATE: Ability = { namespace: "ucan", segments: [ "DELEGATE" ] }
 
 
 

--- a/src/capability/resource-pointer.ts
+++ b/src/capability/resource-pointer.ts
@@ -10,6 +10,10 @@ export type ResourcePointer = {
   hierPart: Superuser | string
 }
 
+
+/**
+ * Separator for pieces of a URI.
+ */
 export const SEPARATOR: string = ":"
 
 

--- a/src/chained.ts
+++ b/src/chained.ts
@@ -64,7 +64,7 @@ export class Chained {
   }
 
   /**
-   * @returns A representation of delgated capabilities throughout all ucan chains
+   * @returns A representation of delegated capabilities throughout all ucan chains
    */
   reduce<A>(reduceLayer: (ucan: Ucan<never>, reducedProofs: () => Iterable<A>) => A): A {
     // eslint-disable-next-line @typescript-eslint/no-this-alias


### PR DESCRIPTION
Closes #43 

This allows you to redelegate capabilities with the `prf` capability, and forward (give access to current and future) capabilities with the `my` + `as` capabilities.

It doesn't enforce the strict combination of `my` and `as` as described in the spec, ie. can't have an `as` cap without a `my` cap. Like I mentioned in a comment in this PR, I couldn't get that to work with our current implementation of the capability iteration. @matheus23 You talked about refactoring that part, so I'm keeping this for another PR.

There's also something here about sub-schemes/sub-resources, such as `my:dnslink`, that I can't quite wrap my head around just yet. I guess that will need some verification/validation API as well? Thoughts @matheus23 @expede?