### PR TITLE
Lock uint8arrays at 3.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/core",
-  "version": "0.11.0-alpha",
+  "version": "0.11.0",
   "description": "Core UCAN implementation",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/core",
-  "version": "0.11.0",
+  "version": "0.11.0-alpha",
   "description": "Core UCAN implementation",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
@@ -65,7 +65,7 @@
     "README.md"
   ],
   "dependencies": {
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/packages/default-plugins/package.json
+++ b/packages/default-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/default-plugins",
-  "version": "0.11.0-alpha",
+  "version": "0.11.0",
   "description": "Default UCAN plugin set",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {

--- a/packages/default-plugins/package.json
+++ b/packages/default-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/default-plugins",
-  "version": "0.11.0",
+  "version": "0.11.0-alpha",
   "description": "Default UCAN plugin set",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
@@ -25,8 +25,8 @@
     "dist:types": "tsc --project ./dist/ --emitDeclarationOnly --declaration --declarationDir ./dist/types/",
     "lint": "eslint src/**/*.ts src/*.ts tests/**/*.ts tests/*.ts",
     "prepare": "yarn build",
-    "publish-alpha": "yarn publish --tag alpha",
-    "publish-stable": "yarn publish --tag latest",
+    "publish-alpha": "yarn publish --tag alpha --access public",
+    "publish-stable": "yarn publish --tag latest --access public",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -65,11 +65,11 @@
     "README.md"
   ],
   "dependencies": {
-    "@ucans/core": "*",
     "@stablelib/ed25519": "^1.0.2",
+    "@ucans/core": "*",
     "big-integer": "^1.6.51",
     "one-webcrypto": "^1.0.3",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/packages/ucans/package.json
+++ b/packages/ucans/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/ucans",
-  "version": "0.11.0",
+  "version": "0.11.0-alpha",
   "description": "Typescript implementation of UCANs with default plugins",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
@@ -25,8 +25,8 @@
     "dist:types": "tsc --project ./dist/ --emitDeclarationOnly --declaration --declarationDir ./dist/types/",
     "lint": "eslint src/**/*.ts src/*.ts",
     "prepare": "yarn build",
-    "publish-alpha": "yarn publish --tag alpha",
-    "publish-stable": "yarn publish --tag latest",
+    "publish-alpha": "yarn publish --tag alpha --access public",
+    "publish-stable": "yarn publish --tag latest -access public",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/ucans/package.json
+++ b/packages/ucans/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucans/ucans",
-  "version": "0.11.0-alpha",
+  "version": "0.11.0",
   "description": "Typescript implementation of UCANs with default plugins",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,14 @@
     "@typescript-eslint/types" "5.30.7"
     eslint-visitor-keys "^3.3.0"
 
+"@ucans/default-plugins@*":
+  version "0.11.0-alpha"
+  dependencies:
+    "@stablelib/ed25519" "^1.0.2"
+    "@ucans/core" "*"
+    big-integer "^1.6.51"
+    one-webcrypto "^1.0.3"
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -3181,7 +3189,7 @@ typescript@^4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
-uint8arrays@^3.0.0:
+uint8arrays@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.0.0.tgz#260869efb8422418b6f04e3fac73a3908175c63b"
   integrity sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==


### PR DESCRIPTION
## Problem
`uint8arrays` had breaking changes in `3.1.0` that use Buffers under the hood (which don't work with webcrypto)

## Solution
Lock `uint8arrays` at `3.0.0`

We'd actually discussed doing this earlier for security reasons & this gave a pretty nice example of why that's important 😅 

Closes https://github.com/ucan-wg/ts-ucan/issues/87