### PR TITLE
Pass typed arrays to WebCrypto instead of ArrayBuffers

### DIFF
--- a/packages/default-plugins/src/p256/crypto.ts
+++ b/packages/default-plugins/src/p256/crypto.ts
@@ -59,7 +59,7 @@ export const importKey = async (
 ): Promise<CryptoKey> => {
   return await webcrypto.subtle.importKey(
     "raw",
-    key.buffer,
+    key,
     { name: ALG, namedCurve: DEFAULT_CURVE },
     true,
     [ "verify" ]
@@ -73,7 +73,7 @@ export const sign = async (
   const buf = await webcrypto.subtle.sign(
     { name: ALG, hash: { name: DEFAULT_HASH_ALG } },
     privateKey,
-    msg.buffer
+    msg
   )
   return new Uint8Array(buf)
 }
@@ -86,8 +86,8 @@ export const verify = async (
   return await webcrypto.subtle.verify(
     { name: ALG, hash: { name: DEFAULT_HASH_ALG } },
     await importKey(pubKey),
-    sig.buffer,
-    msg.buffer
+    sig,
+    msg
   )
 }
 

--- a/packages/default-plugins/src/rsa/crypto.ts
+++ b/packages/default-plugins/src/rsa/crypto.ts
@@ -30,7 +30,7 @@ export const exportKey = async (key: CryptoKey): Promise<Uint8Array> => {
 export const importKey = async (key: Uint8Array): Promise<CryptoKey> => {
   return await webcrypto.subtle.importKey(
     "spki",
-    key.buffer,
+    key,
     { name: RSA_ALG, hash: { name: DEFAULT_HASH_ALG } },
     true,
     [ "verify" ]
@@ -41,7 +41,7 @@ export const sign = async (msg: Uint8Array, privateKey: CryptoKey): Promise<Uint
   const buf = await webcrypto.subtle.sign(
     { name: RSA_ALG, saltLength: SALT_LEGNTH },
     privateKey,
-    msg.buffer
+    msg
   )
   return new Uint8Array(buf)
 }
@@ -50,8 +50,8 @@ export const verify = async (pubKey: Uint8Array, msg: Uint8Array, sig: Uint8Arra
   return await webcrypto.subtle.verify(
     { name: RSA_ALG, saltLength: SALT_LEGNTH },
     await importKey(pubKey),
-    sig.buffer,
-    msg.buffer
+    sig,
+    msg
   )
 }
 


### PR DESCRIPTION
## Problem

[It was pointed out to me](https://github.com/achingbrain/uint8arrays/issues/38#issuecomment-1248983590) doing `typedArray.buffer` is dangerous:
> Because a typed array is a view of a buffer, the underlying buffer may be longer than the typed array itself.

Basically `typedArray !== new Uint8Array(typedArray.buffer)`

This led to the bug we encountered when updating `uint8arrays` from 3.0.0 to 3.1.0.

I believe the WebCrypto API used to _require_ ArrayBuffers, but has since made it more lenient. The docs specifically say that it allows: 
> An [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), a [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) or a [DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) object containing the data...

## Solution

I think it's still good to have that package version locked.

However, I've changed our calls to WebCrypto to use the TypedArray that we're currently working with instead of the underlying ArrayBuffer.
