### PR TITLE
Fix ESM build

### DIFF
--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -1,4 +1,4 @@
-import { hasProp, isRecord } from "./util"
+import { hasProp, isRecord } from "./util.js"
 
 
 // Types

--- a/packages/default-plugins/src/ed25519/crypto.ts
+++ b/packages/default-plugins/src/ed25519/crypto.ts
@@ -1,5 +1,5 @@
-import { EDWARDS_DID_PREFIX } from "../prefixes"
-import { didFromKeyBytes, keyBytesFromDid } from "../util"
+import { EDWARDS_DID_PREFIX } from "../prefixes.js"
+import { didFromKeyBytes, keyBytesFromDid } from "../util.js"
 
 export const didToPublicKey = (did: string): Uint8Array => {
   return keyBytesFromDid(did, EDWARDS_DID_PREFIX)

--- a/packages/default-plugins/src/rsa/crypto.ts
+++ b/packages/default-plugins/src/rsa/crypto.ts
@@ -1,6 +1,6 @@
 import { webcrypto } from "one-webcrypto"
 import * as uint8arrays from "uint8arrays"
-import { RSA_DID_PREFIX, RSA_DID_PREFIX_OLD } from "../prefixes"
+import { RSA_DID_PREFIX, RSA_DID_PREFIX_OLD } from "../prefixes.js"
 import { didFromKeyBytes, keyBytesFromDid } from "../util.js"
 
 export const RSA_ALG = "RSASSA-PKCS1-v1_5"


### PR DESCRIPTION
In ESM, other than in CJS, file endings are not automatically appended to import paths. The TypeScript compiler does not change this behavior; it emits the import statements exactly as written in the TypeScript source file. Imports without `.js` endings are only valid for either packages or named exports set in a package's `package.json`.

This PR fixes the few spots where currently imports without file names are used. This makes the package compatible with Node.js in ESM mode.

I did not yet change all test imports, as they are not included in the published bundle anyways.

Fixes #91 