### PR TITLE
Update SemVer handling & add 0.9.0 compat

### DIFF
--- a/packages/core/src/compatibility.ts
+++ b/packages/core/src/compatibility.ts
@@ -53,7 +53,7 @@ export function handleCompatibility(header: unknown, payload: unknown): UcanPart
 
   // parse either the "ucv" or "uav" as a version in the header
   // we translate 'uav: 1.0.0' into 'ucv: 0.3.0'
-  let version: "0.8.1" | "0.3.0" = "0.8.1"
+  let version: "0.9.1" | "0.3.0" = "0.9.1"
   if (!util.hasProp(header, "ucv") || typeof header.ucv !== "string") {
     if (!util.hasProp(header, "uav") || typeof header.uav !== "string") {
       throw fail("header", "Invalid format: Missing version indicator")

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -28,9 +28,10 @@ const matchesRegex = (regex: RegExp) => (str: string) => {
 }
 
 export function parse(version: string): SemVer | null {
-  let sv = version.match(
+  const sv = version.match(
     /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
   )
+
   if (sv === null) {
     return null
   }
@@ -45,9 +46,9 @@ export function parse(version: string): SemVer | null {
   if (!parts.every(matchesRegex(NUM_REGEX))) {
     return null
   }
-  
-  const [ major, minor, patch ] = parts.map(part => parseInt(part, 10))
-  
+
+  const [major, minor, patch] = parts.map(part => parseInt(part, 10))
+
   if (!Number.isSafeInteger(major) || !Number.isSafeInteger(minor) || !Number.isSafeInteger(patch)) {
     return null
   }

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -28,8 +28,16 @@ const matchesRegex = (regex: RegExp) => (str: string) => {
 }
 
 export function parse(version: string): SemVer | null {
-  const parts = version.split(".")
-  
+  let sv = version.match(
+    /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+  )
+  if (sv === null) {
+    return null
+  }
+
+  const parts =
+    `${sv.groups?.major}.${sv.groups?.minor}.${sv.groups?.patch}`.split(".")
+
   if (parts.length !== 3) {
     return null
   }


### PR DESCRIPTION
This lib is deprecated, but pending wasm-based ts-ucan, we need compat with rs-ucan 0.2.0; this adds that support by implementing parsing of full semver tags including pre-release tags, and updates the ucan version to 0.9.1. In theory this shouldn't break anything? 🧐